### PR TITLE
Add front-end filtering  to All Posts page

### DIFF
--- a/src/components/CheckboxSet.js
+++ b/src/components/CheckboxSet.js
@@ -8,13 +8,14 @@ function CheckboxSet({ checkboxes, callback, title }) {
 
   React.useEffect(() => {
     const newArray = checkboxes.filter((value, index) => checkboxValues[index]).map(item => item.value);
+    // console.log('callback', newArray)
     callback(newArray);
   }, [checkboxValues]);
 
   return (
-    <div className="m-3">
+    <div className="m-3" data-testid="checkboxset">
       <span className="flex flex-row place-content-between">
-        <h3 className="text-center">{title}</h3>
+        <h3 data-testid="title" className="text-center">{title}</h3>
         <button
           type="button"
           className="text-blue-500 underline cursor-pointer block text-xs"
@@ -37,8 +38,8 @@ function CheckboxSet({ checkboxes, callback, title }) {
             className="mr-2 mt-1"
           />
           <span>
-            <div className="leading-tight">{checkbox.label}</div>
-            <div className="text-xs text-gray-500">{checkbox.description}</div>
+            <div data-testid="label" className="leading-tight">{checkbox.label}</div>
+            <div data-testid="description" className="text-xs text-gray-500">{checkbox.description}</div>
           </span>
         </label>
       ))}

--- a/src/components/CheckboxSet.js
+++ b/src/components/CheckboxSet.js
@@ -24,7 +24,7 @@ function CheckboxSet({ checkboxes, callback, title }) {
         </button>
       </span>
       {checkboxes.map((checkbox, index) => (
-        <label key={checkbox.value} className="flex flex-row items-start mt-3">
+        <label key={checkbox.value} className="flex flex-row items-start mt-3 ml-1">
           <input
             type="checkbox"
             name={checkbox.label}

--- a/src/components/CheckboxSet.js
+++ b/src/components/CheckboxSet.js
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+function CheckboxSet({ checkboxes, callback, title }) {
+  const [checkboxValues, setCheckboxValues] = React.useState(new Array(checkboxes.length).fill(false));
+
+  React.useCallback(() => { callback(checkboxValues); }, [callback, checkboxValues]);
+
+  React.useEffect(() => {
+    const newArray = checkboxes.filter((value, index) => checkboxValues[index]).map(item => item.value);
+    callback(newArray);
+  }, [checkboxValues]);
+
+  return (
+    <div className="m-3">
+      <span className="flex flex-row place-content-between">
+        <h3 className="text-center">{title}</h3>
+        <button
+          type="button"
+          className="text-blue-500 underline cursor-pointer block text-xs"
+          onClick={() => setCheckboxValues(new Array(checkboxes.length).fill(false))}
+        >
+          Clear All
+        </button>
+      </span>
+      {checkboxes.map((checkbox, index) => (
+        <label key={checkbox.value} className="flex flex-row items-start mt-3">
+          <input
+            type="checkbox"
+            name={checkbox.label}
+            checked={checkboxValues[index]}
+            onChange={e => {
+              const newCheckboxValues = [...checkboxValues];
+              newCheckboxValues[index] = e.target.checked;
+              setCheckboxValues(newCheckboxValues);
+            }}
+            className="mr-2 mt-1"
+          />
+          <span>
+            <div className="leading-tight">{checkbox.label}</div>
+            <div className="text-xs text-gray-500">{checkbox.description}</div>
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+export default CheckboxSet;
+
+CheckboxSet.propTypes = {
+  checkboxes: PropTypes.array,
+  callback: PropTypes.func,
+  title: PropTypes.string,
+};

--- a/src/pages/allposts.js
+++ b/src/pages/allposts.js
@@ -65,7 +65,7 @@ function AllPostsPage({ data }) {
           {filterPosts().length !== 0 && (
             <h2 data-testid="subtitle" className="mb-3 text-xl w-full text-center">{`${
               filterPosts().length
-            } Posts match your filters`}</h2>
+            } Post${filterPosts().length !== 1 ? "s" : ""} match your filters`}</h2>
           )}
           <div className="flex flex-row flex-wrap h-full" data-testid="posts">
             {filterPosts().length === 0 ? (

--- a/src/pages/allposts.js
+++ b/src/pages/allposts.js
@@ -65,7 +65,7 @@ function AllPostsPage({ data }) {
           {filterPosts().length !== 0 && (
             <h2 data-testid="subtitle" className="mb-3 text-xl w-full text-center">{`${
               filterPosts().length
-            } Post${filterPosts().length !== 1 ? "s" : ""} match your filters`}</h2>
+            } Post${filterPosts().length !== 1 ? "s match" : " matches"} your filters`}</h2>
           )}
           <div className="flex flex-row flex-wrap h-full" data-testid="posts">
             {filterPosts().length === 0 ? (

--- a/src/pages/allposts.js
+++ b/src/pages/allposts.js
@@ -6,25 +6,78 @@ import { graphql } from 'gatsby';
 import Layout from '../components/Layout';
 import Header from '../components/Header';
 import Post from '../components/Post';
+import CheckboxSet from '../components/CheckboxSet';
 
 function AllPostsPage({ data }) {
+  const [ingredientsFilter, setIngredientsFilter] = React.useState([]);
+  const [typeFilter, setTypeFilter] = React.useState([]);
+
+  function filterPosts() {
+    return data.allPosts.nodes
+      .filter(post => post.author)
+      .filter(post => {
+        if (ingredientsFilter.length === 0) return true;
+        return post.tags.some(tag => ingredientsFilter.includes(tag));
+      })
+      .filter(post => {
+        if (typeFilter.length === 0) return true;
+        return post.categories.some(category => typeFilter.includes(category));
+      });
+  }
   return (
     <Layout pageTitle="All Posts">
-      <span>
-        <h2 data-testid="subtitle" className="mb-3 text-xl inline-block">All the Posts</h2>
-        <div className="flex flex-row flex-wrap" data-testid="posts">
-          {data.allPosts.nodes
-            .filter((post) => post.author)
-            .map((post) => <Post key={post.id} post={post} tags={data.allTags.nodes} categories={data.allCategories.nodes} />)}
+      <div className="grid grid-cols-6 gap-3">
+        <div>
+          <div className="text-center">Filters</div>
+          <hr />
+          <CheckboxSet
+            checkboxes={data.allTags.nodes.map(tag => ({
+              description: tag.description,
+              value: tag.tagId,
+              label: tag.name,
+            }))}
+            callback={ingredientsFilter => {
+              setIngredientsFilter(ingredientsFilter);
+            }}
+            title={'Ingredients'}
+          />
+          <hr />
+          <CheckboxSet
+            checkboxes={data.allCategories.nodes.map(category => ({
+              value: category.categoryId,
+              description: category.description,
+              label: category.name,
+            }))}
+            callback={typeFilter => {
+              setTypeFilter(typeFilter);
+            }}
+            title={'Types'}
+          />
         </div>
-      </span>
+        <div className="col-span-5">
+          {filterPosts().length !== 0 && (
+            <h2 data-testid="subtitle" className="mb-3 text-xl w-full text-center">{`${
+              filterPosts().length
+            } Posts match your filters`}</h2>
+          )}
+          <div className="flex flex-row flex-wrap h-full" data-testid="posts">
+            {filterPosts().length === 0 ? (
+              <div className="text-3xl text-gray-400 self-center text-center w-full">No posts match filters</div>
+            ) : (
+              filterPosts().map(post => (
+                <Post key={post.id} post={post} tags={data.allTags.nodes} categories={data.allCategories.nodes} />
+              ))
+            )}
+          </div>
+        </div>
+      </div>
     </Layout>
   );
 }
 
 export const pageQuery = graphql`
   query AllPostsQuery {
-    allPosts(filter: {status: {eq: "publish"}}, sort: {date: ASC}) {
+    allPosts(filter: { status: { eq: "publish" } }, sort: { date: ASC }) {
       nodes {
         author
         categories

--- a/src/pages/allposts.js
+++ b/src/pages/allposts.js
@@ -13,16 +13,21 @@ function AllPostsPage({ data }) {
   const [typeFilter, setTypeFilter] = React.useState([]);
 
   function filterPosts() {
-    return data.allPosts.nodes
-      .filter(post => post.author)
-      .filter(post => {
-        if (ingredientsFilter.length === 0) return true;
-        return post.tags.some(tag => ingredientsFilter.includes(tag));
-      })
-      .filter(post => {
-        if (typeFilter.length === 0) return true;
-        return post.categories.some(category => typeFilter.includes(category));
-      });
+    return (
+      data.allPosts.nodes
+        // Remove posts that have no author. This is sanity check to ensure that the post is all there.
+        .filter(post => post.author)
+        // Filter by ingredients
+        .filter(post => {
+          if (ingredientsFilter.length === 0) return true;
+          return post.tags.some(tag => ingredientsFilter.includes(tag));
+        })
+        // And then filter by type
+        .filter(post => {
+          if (typeFilter.length === 0) return true;
+          return post.categories.some(category => typeFilter.includes(category));
+        })
+    );
   }
   return (
     <Layout pageTitle="All Posts">
@@ -53,6 +58,8 @@ function AllPostsPage({ data }) {
             }}
             title={'Types'}
           />
+          <hr />
+          <p className="text-xs text-gray-500 text-center mt-1">Filters within a set are ORed together. Filter Sets are ANDed together</p>
         </div>
         <div className="col-span-5">
           {filterPosts().length !== 0 && (

--- a/test/allposts.test.js
+++ b/test/allposts.test.js
@@ -3,209 +3,192 @@ import * as Gatsby from 'gatsby';
 import { render, screen } from '@testing-library/react';
 import AllPostsPage from '../src/pages/allposts';
 
-const graphql = jest.spyOn(Gatsby, 'graphql')
-const mockGraphQL = 
-  {
-    "allPosts": {
-        "nodes": [
-            {
-                "author": 1,
-                "categories": [
-                    12
-                ],
-                "id": "9fa1e701-6aa7-5b91-bacf-bef4379f3727",
-                "tags": [
-                    10,
-                    4,
-                    5,
-                    3,
-                    6
-                ],
-                "title": {
-                    "rendered": "Christmas Tray"
-                },
-                "excerpt": {
-                    "rendered": "<p>A tray for our family Christmas celebration. The skeuomorphic trays are fun but are more work and, eventually, get repetitive.</p>\n"
-                },
-                "date": "December 24, 2012 7:12 PM",
-                "postId": 16,
-                "images": [
-                    {
-                        "altText": "An appetizer tray in the shape of a Christmas tree",
-                        "caption": "<p>An appetizer tray in the shape of a Christmas tree</p>\n",
-                        "url": "https://appetizertray.art/wp-content/uploads/2024/04/IMG_1572-scaled.jpg"
-                    }
-                ]
-            },
-            {
-                "author": 1,
-                "categories": [
-                    11
-                ],
-                "id": "12ea0e59-ce83-5834-898d-c2312224849a",
-                "tags": [
-                    9,
-                    8,
-                    6
-                ],
-                "title": {
-                    "rendered": "An Ikea Caprese tray"
-                },
-                "excerpt": {
-                    "rendered": "<p>Some assembly required! It&#8217;s a nice change of pace from the assembled trays, though.</p>\n"
-                },
-                "date": "September 20, 2020 5:09 PM",
-                "postId": 19,
-                "images": [
-                    {
-                        "altText": "A caprese salad",
-                        "caption": "<p>Some assembly required</p>\n",
-                        "url": "https://appetizertray.art/wp-content/uploads/2024/04/IMG_8224-scaled.jpeg"
-                    }
-                ]
-            },
-            {
-                "author": 1,
-                "categories": [
-                    1
-                ],
-                "id": "1269e3d3-dd8f-5b33-92f6-36f4b9e183c2",
-                "tags": [
-                    3,
-                    6
-                ],
-                "title": {
-                    "rendered": "A twisted tray"
-                },
-                "excerpt": {
-                    "rendered": "<p>A simple star tray, slightly twisted, to use up some veggies. Note that there are no cukes here as we were out of them.</p>\n"
-                },
-                "date": "January 14, 2021 5:01 PM",
-                "postId": 27,
-                "images": [
-                    {
-                        "altText": "an appetizer tray in the shape of a twisted star",
-                        "caption": "",
-                        "url": "https://appetizertray.art/wp-content/uploads/2024/04/IMG_8497-scaled.jpeg"
-                    }
-                ]
-            }
+const graphql = jest.spyOn(Gatsby, 'graphql');
+const mockGraphQL = {
+  allPosts: {
+    nodes: [
+      {
+        author: 1,
+        categories: [12],
+        id: '9fa1e701-6aa7-5b91-bacf-bef4379f3727',
+        tags: [10, 4, 5, 3, 6],
+        title: {
+          rendered: 'Christmas Tray',
+        },
+        excerpt: {
+          rendered:
+            '<p>A tray for our family Christmas celebration. The skeuomorphic trays are fun but are more work and, eventually, get repetitive.</p>\n',
+        },
+        date: 'December 24, 2012 7:12 PM',
+        postId: 16,
+        images: [
+          {
+            altText: 'An appetizer tray in the shape of a Christmas tree',
+            caption: '<p>An appetizer tray in the shape of a Christmas tree</p>\n',
+            url: 'https://appetizertray.art/wp-content/uploads/2024/04/IMG_1572-scaled.jpg',
+          },
         ],
-        "totalCount": 3
-    },
-    "allCategories": {
-        "nodes": [
-            {
-                "categoryId": 11,
-                "id": "0ea91562-54d2-5fda-b7e2-04869d480744",
-                "name": "Caprese Salad",
-                "description": "Summer, or mostly summer, caprese salad trays"
-            },
-            {
-                "categoryId": 12,
-                "id": "5dfe6ea5-fc22-53ef-b2b1-4538d7379594",
-                "name": "Holiday",
-                "description": "Holiday themed trays"
-            },
-            {
-                "categoryId": 1,
-                "id": "fb26cf25-e020-5a50-b58b-1baefa675aeb",
-                "name": "Regular",
-                "description": ""
-            },
-            {
-                "categoryId": 13,
-                "id": "1e076d94-4074-5158-ab57-2df814231f1f",
-                "name": "Special Occasion",
-                "description": "Special Occasions like birthdays and such"
-            }
-        ]
-    },
-    "allTags": {
-        "nodes": [
-            {
-                "tagId": 9,
-                "id": "e9cae07f-fadd-566e-9072-6db86efb061e",
-                "description": "For Caprese salads",
-                "name": "Basil"
-            },
-            {
-                "tagId": 10,
-                "id": "47fdd245-6304-5830-a582-5098901b9bed",
-                "description": "Sliced celery stalks ",
-                "name": "Celery"
-            },
-            {
-                "tagId": 4,
-                "id": "27e1fbe5-0b55-5a66-a306-7e5b50553bc7",
-                "description": "Sliced Cucumbers",
-                "name": "Cukes"
-            },
-            {
-                "tagId": 8,
-                "id": "6b6107f6-7e68-5222-98be-5292d9fbe795",
-                "description": "For Caprese Salads ",
-                "name": "Mozzarella"
-            },
-            {
-                "tagId": 5,
-                "id": "0cbdab88-13b6-51c1-861d-590ba944233a",
-                "description": "Pitted Olives",
-                "name": "Olives"
-            },
-            {
-                "tagId": 7,
-                "id": "610b6fa8-e9f0-5eee-bc04-5c8a6c1b734d",
-                "description": "Slices sweet peppers, usually not green",
-                "name": "Peppers"
-            },
-            {
-                "tagId": 3,
-                "id": "f64ab230-5b18-5eef-bd64-7afcf0a8fdeb",
-                "description": "Dill Pickles",
-                "name": "Pickles"
-            },
-            {
-                "tagId": 16,
-                "id": "10a03a99-c04c-5afb-a3a1-0e56aad27b60",
-                "description": "Cooked Shrimp",
-                "name": "Shrimp"
-            },
-            {
-                "tagId": 6,
-                "id": "6c119ef0-da72-5f00-b8d0-07be0a4f2a90",
-                "description": "Usually cherry or grape tomatoes",
-                "name": "Tomatoes"
-            }
-        ]
-    }
-}
+      },
+      {
+        author: 1,
+        categories: [11],
+        id: '12ea0e59-ce83-5834-898d-c2312224849a',
+        tags: [9, 8, 6],
+        title: {
+          rendered: 'An Ikea Caprese tray',
+        },
+        excerpt: {
+          rendered:
+            '<p>Some assembly required! It&#8217;s a nice change of pace from the assembled trays, though.</p>\n',
+        },
+        date: 'September 20, 2020 5:09 PM',
+        postId: 19,
+        images: [
+          {
+            altText: 'A caprese salad',
+            caption: '<p>Some assembly required</p>\n',
+            url: 'https://appetizertray.art/wp-content/uploads/2024/04/IMG_8224-scaled.jpeg',
+          },
+        ],
+      },
+      {
+        author: 1,
+        categories: [1],
+        id: '1269e3d3-dd8f-5b33-92f6-36f4b9e183c2',
+        tags: [3, 6],
+        title: {
+          rendered: 'A twisted tray',
+        },
+        excerpt: {
+          rendered:
+            '<p>A simple star tray, slightly twisted, to use up some veggies. Note that there are no cukes here as we were out of them.</p>\n',
+        },
+        date: 'January 14, 2021 5:01 PM',
+        postId: 27,
+        images: [
+          {
+            altText: 'an appetizer tray in the shape of a twisted star',
+            caption: '',
+            url: 'https://appetizertray.art/wp-content/uploads/2024/04/IMG_8497-scaled.jpeg',
+          },
+        ],
+      },
+    ],
+    totalCount: 3,
+  },
+  allCategories: {
+    nodes: [
+      {
+        categoryId: 11,
+        id: '0ea91562-54d2-5fda-b7e2-04869d480744',
+        name: 'Caprese Salad',
+        description: 'Summer, or mostly summer, caprese salad trays',
+      },
+      {
+        categoryId: 12,
+        id: '5dfe6ea5-fc22-53ef-b2b1-4538d7379594',
+        name: 'Holiday',
+        description: 'Holiday themed trays',
+      },
+      {
+        categoryId: 1,
+        id: 'fb26cf25-e020-5a50-b58b-1baefa675aeb',
+        name: 'Regular',
+        description: '',
+      },
+      {
+        categoryId: 13,
+        id: '1e076d94-4074-5158-ab57-2df814231f1f',
+        name: 'Special Occasion',
+        description: 'Special Occasions like birthdays and such',
+      },
+    ],
+  },
+  allTags: {
+    nodes: [
+      {
+        tagId: 9,
+        id: 'e9cae07f-fadd-566e-9072-6db86efb061e',
+        description: 'For Caprese salads',
+        name: 'Basil',
+      },
+      {
+        tagId: 10,
+        id: '47fdd245-6304-5830-a582-5098901b9bed',
+        description: 'Sliced celery stalks ',
+        name: 'Celery',
+      },
+      {
+        tagId: 4,
+        id: '27e1fbe5-0b55-5a66-a306-7e5b50553bc7',
+        description: 'Sliced Cucumbers',
+        name: 'Cukes',
+      },
+      {
+        tagId: 8,
+        id: '6b6107f6-7e68-5222-98be-5292d9fbe795',
+        description: 'For Caprese Salads ',
+        name: 'Mozzarella',
+      },
+      {
+        tagId: 5,
+        id: '0cbdab88-13b6-51c1-861d-590ba944233a',
+        description: 'Pitted Olives',
+        name: 'Olives',
+      },
+      {
+        tagId: 7,
+        id: '610b6fa8-e9f0-5eee-bc04-5c8a6c1b734d',
+        description: 'Slices sweet peppers, usually not green',
+        name: 'Peppers',
+      },
+      {
+        tagId: 3,
+        id: 'f64ab230-5b18-5eef-bd64-7afcf0a8fdeb',
+        description: 'Dill Pickles',
+        name: 'Pickles',
+      },
+      {
+        tagId: 16,
+        id: '10a03a99-c04c-5afb-a3a1-0e56aad27b60',
+        description: 'Cooked Shrimp',
+        name: 'Shrimp',
+      },
+      {
+        tagId: 6,
+        id: '6c119ef0-da72-5f00-b8d0-07be0a4f2a90',
+        description: 'Usually cherry or grape tomatoes',
+        name: 'Tomatoes',
+      },
+    ],
+  },
+};
 
 beforeEach(() => {
-  graphql.mockImplementation(() => mockGraphQL)
-})
+  graphql.mockImplementation(() => mockGraphQL);
+});
 
 afterEach(() => {
-  jest.restoreAllMocks()
-})
+  jest.restoreAllMocks();
+});
 
 describe('Test AllPosts Page', () => {
   it('Has the post subtitle', () => {
-    const { getByTestId } = render(<AllPostsPage data={mockGraphQL}  />);
+    const { getByTestId } = render(<AllPostsPage data={mockGraphQL} />);
     const node = getByTestId('subtitle');
 
-    expect(node).toHaveTextContent('All the Posts');
-    expect(node.className).toBe('mb-3 text-xl inline-block');
+    expect(node).toHaveTextContent(`${mockGraphQL.allPosts.totalCount} Posts match your filters`);
+    expect(node.className).toBe('mb-3 text-xl w-full text-center');
   });
   it('Contains the proper number of posts', () => {
-    const { getByTestId } = render(<AllPostsPage data={mockGraphQL}  />);
+    const { getByTestId } = render(<AllPostsPage data={mockGraphQL} />);
     const node = getByTestId('posts');
 
     const sections = node.querySelectorAll('section');
     expect(sections.length).toBe(mockGraphQL.allPosts.totalCount);
   });
   it('Contains the proper number of images in the post', () => {
-    const { getByTestId } = render(<AllPostsPage data={mockGraphQL}  />);
+    const { getByTestId } = render(<AllPostsPage data={mockGraphQL} />);
     const node = getByTestId('posts');
 
     const firstUL = node.querySelector('section ul');
@@ -213,7 +196,7 @@ describe('Test AllPosts Page', () => {
     expect(li.length).toBe(1);
   });
   it('The post contains a figure', () => {
-    const { getByTestId } = render(<AllPostsPage data={mockGraphQL}  />);
+    const { getByTestId } = render(<AllPostsPage data={mockGraphQL} />);
     const node = getByTestId('posts');
 
     const firstLI = node.querySelector('section ul li');

--- a/test/allposts.test.js
+++ b/test/allposts.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Gatsby from 'gatsby';
-import { render, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import AllPostsPage from '../src/pages/allposts';
 
 const graphql = jest.spyOn(Gatsby, 'graphql');
@@ -202,5 +202,14 @@ describe('Test AllPosts Page', () => {
     const firstLI = node.querySelector('section ul li');
     const figure = firstLI.querySelectorAll('figure');
     expect(figure.length).toBe(1);
+  });
+  it('Clicking the Holiday checkbox results in one post being found', () => {
+    const { getByTestId } = render(<AllPostsPage data={mockGraphQL} />);
+    // Click holiday checkbox
+    fireEvent.click(screen.getByText('Holiday'));
+
+    const node = getByTestId('subtitle');
+    expect(node).toHaveTextContent('1 Post matches your filters');
+
   });
 });

--- a/test/checkboxset.test.js
+++ b/test/checkboxset.test.js
@@ -1,0 +1,146 @@
+import * as React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import CheckboxSet from '../src/components/CheckboxSet';
+import { all } from 'micromatch';
+
+const allCategories = [
+  {
+    categoryId: 11,
+    id: '0ea91562-54d2-5fda-b7e2-04869d480744',
+    name: 'Caprese Salad',
+    description: 'Summer, or mostly summer, caprese salad trays',
+  },
+  {
+    categoryId: 12,
+    id: '5dfe6ea5-fc22-53ef-b2b1-4538d7379594',
+    name: 'Holiday',
+    description: 'Holiday themed trays',
+  },
+  {
+    categoryId: 1,
+    id: 'fb26cf25-e020-5a50-b58b-1baefa675aeb',
+    name: 'Regular',
+    description: '',
+  },
+  {
+    categoryId: 13,
+    id: '1e076d94-4074-5158-ab57-2df814231f1f',
+    name: 'Special Occasion',
+    description: 'Special Occasions like birthdays and such',
+  },
+].map(category => ({
+  value: category.categoryId,
+  description: category.description,
+  label: category.name,
+}));
+
+const allTags = [
+  {
+    tagId: 9,
+    id: 'e9cae07f-fadd-566e-9072-6db86efb061e',
+    description: 'For Caprese salads',
+    name: 'Basil',
+  },
+  {
+    tagId: 10,
+    id: '47fdd245-6304-5830-a582-5098901b9bed',
+    description: 'Sliced celery stalks ',
+    name: 'Celery',
+  },
+  {
+    tagId: 4,
+    id: '27e1fbe5-0b55-5a66-a306-7e5b50553bc7',
+    description: 'Sliced Cucumbers',
+    name: 'Cukes',
+  },
+  {
+    tagId: 8,
+    id: '6b6107f6-7e68-5222-98be-5292d9fbe795',
+    description: 'For Caprese Salads ',
+    name: 'Mozzarella',
+  },
+  {
+    tagId: 5,
+    id: '0cbdab88-13b6-51c1-861d-590ba944233a',
+    description: 'Pitted Olives',
+    name: 'Olives',
+  },
+  {
+    tagId: 7,
+    id: '610b6fa8-e9f0-5eee-bc04-5c8a6c1b734d',
+    description: 'Slices sweet peppers, usually not green',
+    name: 'Peppers',
+  },
+  {
+    tagId: 3,
+    id: 'f64ab230-5b18-5eef-bd64-7afcf0a8fdeb',
+    description: 'Dill Pickles',
+    name: 'Pickles',
+  },
+  {
+    tagId: 16,
+    id: '10a03a99-c04c-5afb-a3a1-0e56aad27b60',
+    description: 'Cooked Shrimp',
+    name: 'Shrimp',
+  },
+  {
+    tagId: 6,
+    id: '6c119ef0-da72-5f00-b8d0-07be0a4f2a90',
+    description: 'Usually cherry or grape tomatoes',
+    name: 'Tomatoes',
+  },
+].map(tag => ({
+  value: tag.tagId,
+  description: tag.description,
+  label: tag.name,
+}));
+
+const setIngredientsFilter = jest.fn();
+const setTypeFilter = jest.fn();
+
+describe('Test Checkbox Set Componment', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Creates the title properly', () => {
+    const { getByTestId } = render(<CheckboxSet checkboxes={allCategories} callback={setTypeFilter} title={'Types'} />);
+    const node = getByTestId('title');
+
+    expect(node).toHaveTextContent('Types');
+  });
+  it('Contains the proper number of checkboxes', () => {
+    const { getByTestId } = render(<CheckboxSet checkboxes={allCategories} callback={setTypeFilter} title={'Types'} />);
+    const node = getByTestId('checkboxset');
+
+    const sections = node.querySelectorAll('input[type="checkbox"]');
+    expect(sections.length).toBe(allCategories.length);
+  });
+  it('Verify clicking a checkbox calls the callback event', () => {
+    render(<CheckboxSet checkboxes={allCategories} callback={setTypeFilter} title={'Types'} />);
+    // Called on component render
+    expect(setTypeFilter).toHaveBeenCalledTimes(1);
+    expect(setTypeFilter.mock.calls[0][0]).toStrictEqual([]);
+
+    // Click holiday checkbox
+    fireEvent.click(screen.getByText('Holiday'));
+
+    expect(setTypeFilter).toHaveBeenCalledTimes(2);
+    const expected = [allCategories.find(category => category.label === 'Holiday').value];
+    expect(setTypeFilter.mock.calls[1][0]).toStrictEqual(expected);
+
+  });
+  it('Verify clicking a checkbox calls the callback event', () => {
+    render(<CheckboxSet checkboxes={allTags} callback={setIngredientsFilter} title={'Ingredients'} />);
+    // Called on component render
+    expect(setIngredientsFilter).toHaveBeenCalledTimes(1);
+    expect(setIngredientsFilter.mock.calls[0][0]).toStrictEqual([]);
+
+    // Click Pickles checkbox
+    fireEvent.click(screen.getByText('Pickles'));
+
+    expect(setIngredientsFilter).toHaveBeenCalledTimes(2);
+    const expected = [allTags.find(tag => tag.label === 'Pickles').value];
+    expect(setIngredientsFilter.mock.calls[1][0]).toStrictEqual(expected);
+  });
+});


### PR DESCRIPTION
This PR adds the ability to filter posts based on either ingredients (tags) or types (categories). A new component, `CheckboxSet` handles drawing the responding to checkboxes being clicked on or off and uses a callback function to tell the All Posts page what ingredients/types to display. Also added tests for the `CheckboxSet` and more tests for the `allposts` page.